### PR TITLE
Fix a Typo Error

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -58,7 +58,7 @@ async function confirm() {
         <img
           src="~/assets/maimai.webp"
           class="inline-block size-18 mr-4 object-cover"
-          alt="舞萌 2024"
+          alt="舞萌 2025"
         >
         <h1 class="text-2xl font-bold">
           给自己写一张
@@ -71,7 +71,7 @@ async function confirm() {
           <SubmitterInput v-model="form.submitter" />
         </div>
         <p class="text-xs">
-          https://maimai-2024.by-ts.top
+          https://maimai-2025.by-ts.top
         </p>
       </div>
     </div>

--- a/app/components/part/Highlight.vue
+++ b/app/components/part/Highlight.vue
@@ -9,7 +9,7 @@ const form = inject(FormInjectKey)!;
 <template>
   <section>
     <h2 class="mb-1 font-semibold">
-      #2 你的 2024 之最
+      #2 你的 2025 之最
     </h2>
 
     <div class="grid grid-cols-5 text-xs w-full gap-0 whitespace-nowrap">

--- a/app/components/part/Prospect.vue
+++ b/app/components/part/Prospect.vue
@@ -10,7 +10,7 @@ const form = inject(FormInjectKey)!;
 <template>
   <section>
     <h2 class="mb-1 font-semibold">
-      #3 对舞萌 2025 的想法
+      #3 对舞萌 2026 的想法
     </h2>
 
     <div class="flex text-xs gap-2 ml-2">


### PR DESCRIPTION
## Description

### What this Pull Request do?

This Pull Request is about fixing some typos of Vue code, which expected to display the "舞萌 DX 2025" instead of "舞萌 DX 2024".

### What we did?

In Vue part, we did the list below:

1. Modified the [app.vue](https://github.com/RinLin-NYA/maimai-annual/blob/d4a8e3c7a44d7e616ca141ee3e1bca92d8d7a121/app/app.vue) to modify the Title of the picture to "舞萌 DX 2025".
2. Modifyed the [Highlight.vue](https://github.com/RinLin-NYA/maimai-annual/blob/d4a8e3c7a44d7e616ca141ee3e1bca92d8d7a121/app/components/part/Highlight.vue) to modify the Subtitle to "舞萌 DX 2025".
3. Modifyed the [Prospect.vue](https://github.com/RinLin-NYA/maimai-annual/blob/d4a8e3c7a44d7e616ca141ee3e1bca92d8d7a121/app/components/part/Prospect.vue) to change the Subtitle to "舞萌 DX 2026".

### What we didn't do?

Restricted by the development environment, we're unable to running a test of our change, but after a quick review, we believe it should work.